### PR TITLE
Add SwapSwitchCase

### DIFF
--- a/cmd/godzilla/main.go
+++ b/cmd/godzilla/main.go
@@ -178,6 +178,7 @@ func main() {
 		godzilla.BooleanOperatorsMutator,
 		godzilla.NegateConditionalsMutator,
 		godzilla.FloatComparisonInverter,
+		godzilla.SwapSwitchCase,
 		//godzilla.ReturnValueMutator,
 		//godzilla.DebugInspect,
 	}


### PR DESCRIPTION
- Before looping over `sstmt.Body.List`, I did previously check to see if `.Body` was ever nil, and couldn't find any condition where it was nil, so I'd removed the check for brevity.
- I'm not making any calls to covered(), I presume I would need to?
- Any value in just swapping the case statements around instead of swapping the body?
- There's probably an equivalent TypeSwitchStmt opportunity here too, if this is even a valid mutator.
- The `for` might be able to be reduce by one iteration when there's only two elements (it'd do the same swaps), I didn't include that check in this, but it might be valid as performance is probably a concern.

Tested it via the following, and if I added or removed the `t.Errorf` it would have either 3 killed or none, so appears to work based on this test and my understanding.

```
diff --git a/testpkg/a.go b/testpkg/a.go
index a61c8ec..26c414f 100644
--- a/testpkg/a.go
+++ b/testpkg/a.go
@@ -165,3 +165,14 @@ func Zoo2() {
        n, m := Bar()
        _, _ = n, m
 }
+
+func Switch(a int) int {
+       switch a {
+       case 1:
+               return a
+       case 2:
+               return a - 1
+       default:
+               return a - 2
+       }
+}
diff --git a/testpkg/a_test.go b/testpkg/a_test.go
index 722920d..889814c 100644
--- a/testpkg/a_test.go
+++ b/testpkg/a_test.go
@@ -16,3 +16,19 @@ func TestBar(t *testing.T) {
 }
 func TestZoo1(t *testing.T) {}
 func TestZoo2(t *testing.T) {}
+
+func TestSwitch(t *testing.T) {
+       tests := []struct {
+               in  int
+               exp int
+       }{
+               {1, 1}, {2, 1}, {3, 1},
+       }
+
+       for _, test := range tests {
+               got := Switch(test.in)
+               if got != test.exp {
+                       t.Errorf("in: %v got: %v exp: %v", test.in, got, test.exp)
+               }
+       }
+}
```