### PR TITLE
assign args of void calls to blank

### DIFF
--- a/mutators.go
+++ b/mutators.go
@@ -138,13 +138,13 @@ func VoidCallRemoverMutator(parseInfo ParseInfo, node ast.Node, tester Tester) {
 		copy(mutation, block.List)
 
 		if call, ok := expr.X.(*ast.CallExpr); ok {
-		        // assign the function and any args to blank
-			blanks := make([]ast.Expr, len(call.Args) + 1)
+			// assign the function and any args to blank
+			blanks := make([]ast.Expr, len(call.Args)+1)
 			for j := range blanks {
 				blanks[j] = &ast.Ident{Name: "_"}
 			}
 
-			exprs := make([]ast.Expr, len(call.Args) + 1)
+			exprs := make([]ast.Expr, len(call.Args)+1)
 			exprs[0] = call.Fun
 			copy(exprs[1:], call.Args)
 

--- a/mutators.go
+++ b/mutators.go
@@ -136,7 +136,22 @@ func VoidCallRemoverMutator(parseInfo ParseInfo, node ast.Node, tester Tester) {
 
 		mutation := make([]ast.Stmt, len(block.List))
 		copy(mutation, block.List)
-		mutation = mutation[:i+copy(mutation[i:], mutation[i+1:])]
+
+		if call, ok := expr.X.(*ast.CallExpr); ok && len(call.Args) > 0 {
+			blanks := make([]ast.Expr, len(call.Args))
+			for j := range blanks {
+				blanks[j] = &ast.Ident{Name: "_"}
+			}
+			blankAssign := &ast.AssignStmt{
+				Lhs: blanks,
+				Tok: token.ASSIGN,
+				Rhs: call.Args,
+			}
+			mutation[i] = blankAssign
+		} else {
+			mutation = mutation[:i+copy(mutation[i:], mutation[i+1:])]
+		}
+
 		old := block.List
 		block.List = mutation
 

--- a/mutators.go
+++ b/mutators.go
@@ -137,15 +137,21 @@ func VoidCallRemoverMutator(parseInfo ParseInfo, node ast.Node, tester Tester) {
 		mutation := make([]ast.Stmt, len(block.List))
 		copy(mutation, block.List)
 
-		if call, ok := expr.X.(*ast.CallExpr); ok && len(call.Args) > 0 {
-			blanks := make([]ast.Expr, len(call.Args))
+		if call, ok := expr.X.(*ast.CallExpr); ok {
+		        // assign the function and any args to blank
+			blanks := make([]ast.Expr, len(call.Args) + 1)
 			for j := range blanks {
 				blanks[j] = &ast.Ident{Name: "_"}
 			}
+
+			exprs := make([]ast.Expr, len(call.Args) + 1)
+			exprs[0] = call.Fun
+			copy(exprs[1:], call.Args)
+
 			blankAssign := &ast.AssignStmt{
 				Lhs: blanks,
 				Tok: token.ASSIGN,
-				Rhs: call.Args,
+				Rhs: exprs,
 			}
 			mutation[i] = blankAssign
 		} else {


### PR DESCRIPTION
avoids some unused var errors. they can still happen if the function/method expr itself is the only use of a var